### PR TITLE
Use getBodyParam() to extract the 'role' body parameter for the space…

### DIFF
--- a/controllers/space/MembershipController.php
+++ b/controllers/space/MembershipController.php
@@ -92,7 +92,7 @@ class MembershipController extends BaseController
             return $this->returnError(404, 'Membership not found!');
         }
 
-        $newRole = Yii::$app->request->get('role');
+        $newRole = Yii::$app->request->getBodyParam('role');
         if (!in_array($newRole, ['admin', 'moderator', 'member'])) {
             return $this->returnError(400, 'Invalid role given!');
         }

--- a/docs/postman/HumHub API.postman_collection.json
+++ b/docs/postman/HumHub API.postman_collection.json
@@ -708,7 +708,7 @@
 						"method": "PATCH",
 						"header": [],
 						"url": {
-							"raw": "{{API_URL}}/space/1/membership/3/role?role=admin",
+							"raw": "{{API_URL}}/space/1/membership/3/role",
 							"host": [
 								"{{API_URL}}"
 							],


### PR DESCRIPTION
…/membership REST call.

The membership REST call for the space api takes 'role' as a query/body parameter through a PATCH call, see https://www.humhub.com/en/marketplace/rest/docs/html/space.html#tag/Membership/paths/~1space~1{id}~1membership~1{userId}~1role/patch

The correct way to extract it in Yii is getBodyParam(), see https://www.yiiframework.com/doc/guide/2.0/en/runtime-requests#request-parameters

The code currently erroneously, uses 'get()' which is good for a GET request, not a PATCH.