### PR TITLE
Fix #143: On user creation, status is always 1 even if set to another value

### DIFF
--- a/controllers/user/UserController.php
+++ b/controllers/user/UserController.php
@@ -190,6 +190,9 @@ class UserController extends BaseController
     public function actionCreate()
     {
         $apiUser = new ApiUser();
+        if (Yii::$app->user->isAdmin()) {
+            $apiUser->user->scenario = User::SCENARIO_EDIT_ADMIN;
+        }
         $apiUser->load(Yii::$app->request->getBodyParam('account', []), '');
         $apiUser->validate();
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 - Enh #134: Implementation of the user account `visibility` property in [the "Update an existing user" endpoint](https://marketplace.humhub.com/module/rest/docs/html/user.html#tag/User/operation/updateUser)
 - Enh #141: Tests for `next` version
 - Fix #142: Fix visibility of the method `Controller::getAccessRules()`
+- Fix #143: On user creation, status is always 1 even if set to another value
 
 0.9.2 (June 14, 2023)
 ---------------------


### PR DESCRIPTION
Issue: https://github.com/humhub/rest/issues/143