### PR TITLE
Add support for ContentAddon objects in actionFindByObject in the LikeController

### DIFF
--- a/controllers/like/LikeController.php
+++ b/controllers/like/LikeController.php
@@ -8,27 +8,40 @@
 
 namespace humhub\modules\rest\controllers\like;
 
-use humhub\modules\content\models\Content;
+use humhub\components\behaviors\PolymorphicRelation;
+use humhub\helpers\DataTypeHelper;
+use humhub\modules\content\components\ContentActiveRecord;
+use humhub\modules\content\components\ContentAddonActiveRecord;
 use humhub\modules\rest\components\BaseController;
 use humhub\modules\rest\definitions\LikeDefinitions;
 use humhub\modules\like\models\Like;
+
 use Yii;
 
 class LikeController extends BaseController
 {
     public function actionFindByObject()
     {
-        $contentFilter = [
-            'object_model' => Yii::$app->request->get('model'),
-            'object_id' => (int)Yii::$app->request->get('pk'),
-        ];
-        $content = Content::findOne($contentFilter);
-        if ($content === null) {
-            return $this->returnError(404, 'Content not found!');
+        $model = Yii::$app->request->get('model');
+        $pk = (int)Yii::$app->request->get('pk');
+
+        if (DataTypeHelper::matchClassType($model, [ContentActiveRecord::class, ContentAddonActiveRecord::class]) === null) {
+            return $this->returnError(400, 'Invalid object model!');
         }
-        if (!$content->canView()) {
+
+        $object = $model::findOne(['id' => $pk]);
+        if ($object === null) {
+            return $this->returnError(404, 'Object model not found!');
+        }
+
+        if (!$object->content->canView()) {
             return $this->returnError(403, 'You cannot view this content!');
         }
+
+        $contentFilter = [
+            'object_model' => PolymorphicRelation::getObjectModel($object),
+            'object_id' => $object->getPrimaryKey(),
+        ];
 
         $results = [];
         $query = Like::find();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 - Fix #209: Invite created via `user/invite` endpoint now sets the language correctly
 - Fix #211: Update test user passwords
+- Fix #214: Switch to using PolymorphicRelation::getObjectModel() in LikeController::actionFindByObject so likes can be fetched for ContentAddon models
 
 0.10.10 (May 20, 2025)
 ----------------------


### PR DESCRIPTION
Fixes #214: LikeController::actionFindByObject returning 404 when trying to get likes for comments.

Switched to using `PolymorphicRelation::getObjectModel()` which works for both `ContentActiveRecords` as well as `ContentAddonActiveRecords`.

Didn't see any contribution guidelines so give me a shout if there are tests that are missing or now broken.