### PR TITLE
Fix: Make m230401_174208_add_allow_jwt_auth migration resilient when module is not bootstrapped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 0.11.5 (Unreleased)
 -------------------
+- Fix: Make m230401_174208_add_allow_jwt_auth migration resilient when module is not bootstrapped
 - Enh: Automated code refactoring for HumHub 1.18 using Rector
 
 0.11.4 (May 28, 2026)

--- a/migrations/m230401_174208_add_allow_jwt_auth.php
+++ b/migrations/m230401_174208_add_allow_jwt_auth.php
@@ -7,11 +7,19 @@ class m230401_174208_add_allow_jwt_auth extends Migration
 {
     public function safeUp()
     {
-        /** @var Module $module */
-        $module = Yii::$app->getModule('rest');
+        $jwtKey = $this->db->createCommand(
+            'SELECT value FROM setting WHERE module_id = :m AND name = :n',
+            [':m' => 'rest', ':n' => 'jwtKey']
+        )->queryScalar();
 
-        $module->settings->set('enableJwtAuth', !empty($module->settings->get('jwtKey')));
-        $module->settings->set('enableBasicAuth', 1);
+        $this->upsert('setting',
+            ['module_id' => 'rest', 'name' => 'enableJwtAuth', 'value' => !empty($jwtKey) ? '1' : '0'],
+            ['value' => !empty($jwtKey) ? '1' : '0']
+        );
+        $this->upsert('setting',
+            ['module_id' => 'rest', 'name' => 'enableBasicAuth', 'value' => '1'],
+            ['value' => '1']
+        );
     }
 
     public function safeDown()


### PR DESCRIPTION
## Summary

- Replace `Yii::$app->getModule('rest')->settings` calls with direct `setting` table queries — the module may not be registered during `migrate/up` (core `#[WithoutModuleAutoload]` skips third-party module bootstrap)
- Use `upsert()` for writing settings, making the migration naturally idempotent

## Test plan

- [ ] Run `migrate/up` on an instance where rest was previously installed — migration should complete without errors
- [ ] Run `migrate/up` a second time — upsert makes it idempotent, should skip cleanly
- [ ] Verify `enableJwtAuth` is set correctly based on whether `jwtKey` was previously configured