### PR TITLE
Remove obsolete twofa.beforeCheck listener

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -11,8 +11,6 @@ namespace humhub\modules\rest;
 use humhub\components\bootstrap\ModuleAutoLoader;
 use humhub\components\Module as BaseModule;
 use Yii;
-use yii\base\Action;
-use yii\base\Event;
 use yii\helpers\Url;
 
 class Module extends BaseModule
@@ -105,17 +103,4 @@ class Module extends BaseModule
         return !isset($apiModules[$moduleId]) || $apiModules[$moduleId];
     }
 
-    public function beforeAction($action)
-    {
-        static::ignoreTwofaCheck($action);
-
-        return parent::beforeAction($action);
-    }
-
-    public static function ignoreTwofaCheck(Action $action): void
-    {
-        Yii::$app->on('twofa.beforeCheck', function (Event $event) use ($action): void {
-            $event->handled = $action->controller->id !== 'admin-user';
-        });
-    }
 }

--- a/components/BaseController.php
+++ b/components/BaseController.php
@@ -16,7 +16,6 @@ use humhub\modules\rest\components\behaviors\LanguagePickerBehavior;
 use humhub\modules\rest\components\User as UserComponent;
 use humhub\modules\rest\components\auth\JwtAuth;
 use humhub\modules\rest\controllers\auth\AuthController;
-use humhub\modules\rest\Module as RestModule;
 use humhub\modules\rest\models\ConfigureForm;
 use humhub\modules\user\models\User;
 use Yii;
@@ -95,8 +94,6 @@ abstract class BaseController extends Controller
      */
     public function beforeAction($action)
     {
-        RestModule::ignoreTwofaCheck($action);
-
         Yii::$app->set('user', [
             'class' => UserComponent::class,
             'identityClass' => User::class,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.12.2 (Unreleased)
+-------------------
+- Chg: Removed the obsolete `twofa.beforeCheck` listener (`Module::ignoreTwofaCheck()`) — the event no longer exists since the twofa module moved to the core user gate system; token-authenticated API requests are not intercepted by the gate, so the REST API keeps working for users with 2FA enabled without any opt-out
+
 0.12.1 (July 8, 2026)
 ---------------------
 - Fix #245: Update user images

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
         "api",
         "rest"
     ],
-    "version": "0.12.1",
+    "version": "0.12.2",
     "homepage": "https://github.com/humhub/rest",
     "humhub": {
         "minVersion": "1.19"


### PR DESCRIPTION
The twofa module moved from a `Controller::EVENT_BEFORE_ACTION` handler to the core user gate system (humhub/twofa#118, twofa 1.4). As part of that, the `twofa.beforeCheck` event was removed.

The REST module listened on that event (`Module::ignoreTwofaCheck()`, called from `Module::beforeAction()` and `BaseController::beforeAction()`) to keep its endpoints out of the 2FA check. With the event gone, that code no longer does anything.

This removes the dead listener and its calls. No behavior change: `TwofaGate::appliesTo()` does not apply to token-authenticated API requests (humhub/twofa#120), so the REST API keeps working for users with 2FA enabled without needing to opt out.

`$doNotInterceptActionIds` on `BaseController` is left untouched — it is a generic core flag, not part of this cleanup.

Requires twofa >= 1.4.
